### PR TITLE
add: deploy script to use circleCI deploy-prod task

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ mvn install
 
 To deploy it to a remote Maven repository instead, configure the settings of the repository and execute:
 ```shell
-mvn deploy
+bash deploy.sh
 ```
 
 Refer to the [official documentation](https://maven.apache.org/plugins/maven-deploy-plugin/usage.html) for more information.

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,12 @@
+#/bin/sh
+
+# This bash script works around our circleCI config file. We're not using it as our CI doesn't function anymore.
+# Simply run bash deploy.sh to consolidate your changes in production.
+
+echo "Cloning severino..."
+sleep 1
+git clone git@github.com:sizebay/Severino.git utils
+
+echo "Running pseudo-circleCI task"
+mvn -s utils/sizebay-circleci/circle.maven-settings.xml -Dconfig.skip.tests=true clean deploy
+


### PR DESCRIPTION
As of today, our circleCI routine is broken due to past happenings. In order to make the deploy process practical once again, I've separated the `deploy-prod` job from `circle.yml` (which we're not actively using anymore) into a `bash` file.

**Note**: this change is purely ephemeral. At the moment we properly fix our CI, this bash script will eventually die.